### PR TITLE
Fix a bug to emphasise space characters

### DIFF
--- a/bauten.js
+++ b/bauten.js
@@ -24,6 +24,7 @@
         'triangle':     { 'open': '△',  'filled': '▲'},
         'sesame':       { 'open': '﹆',  'filled': '﹅'}
     };
+    bauten._regexIgnoredChars = /[\s　\(\)（）\[\]「」［］]/;
     bauten._applyAll = function(elements, style) {
         if(style != null && style.style != null) {
             var emphasisChar = bauten._getEmphasisChar(style);
@@ -104,7 +105,13 @@
             var rb = d.createElement('RB');
             ruby.appendChild(rb);
 
-            var text1 = d.createTextNode(text.charAt(i));
+            var pointChar = emphasisChar;
+            var c = text.charAt(i);
+            if(c.match(bauten._regexIgnoredChars)) {
+                pointChar = '';
+            }
+
+            var text1 = d.createTextNode(c);
             rb.appendChild(text1);
 
             var rt = d.createElement('RT');
@@ -112,7 +119,7 @@
             if(color != null) {
                 rt.setAttribute('style', 'color:' + color);
             }
-            rt.appendChild(d.createTextNode(emphasisChar));
+            rt.appendChild(d.createTextNode(pointChar));
         }
         return span;
     };

--- a/test/text-em-spaces.html
+++ b/test/text-em-spaces.html
@@ -1,0 +1,24 @@
+<html>
+<head>
+<title>sample of bauten</title>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<style>
+</style>
+</head>
+<body>
+    <h1>text-em-spaces</h1>
+<blockquote>
+    <h2>圏点</h2>
+    <p><em>  （圏　点）    (［け  ん  て  ん］  )  </em><br/>
+    <strong>  「傍　点」　 ( [ ぼ  う  て  ん ] )   </em></p>
+</blockquote>
+<script type="text/javascript" src="../bauten.js"></script>
+<script type="text/javascript">
+bauten(
+        { 'tagName': 'EM', 'style': 'open double-circle', 'color': 'gray'},
+        { 'tagName': 'STRONG', 'style': '♪', 'color': 'cyan' }
+      );
+</script>
+</body>
+</html>
+


### PR DESCRIPTION
The characters like spaces or braces is not to be emphasised.

Added codes to fix it:
- defined regex to check the each characters to be emphasized.
- checked each characters by the regex.
- if the character is not to be emphasized, a blank RT will be added.

This bug fix will close the issue  #13.
