### PR TITLE
Add a feature of 'text-emphasis-position' style

### DIFF
--- a/bauten.js
+++ b/bauten.js
@@ -29,7 +29,8 @@
             var emphasisChar = bauten._getEmphasisChar(style);
             if(emphasisChar != null) {
                 elements.forEach(function(element) {
-                    bauten._applyElement(element, emphasisChar, style.color);
+                    bauten._applyElement(element, emphasisChar, style.color,
+                            style.position);
                 });
             }
         }
@@ -62,7 +63,9 @@
         }
         return emphasisChar;
     }
-    bauten._applyElement = function(element, emphasisChar, color) {
+    bauten._applyElement = function(element, emphasisChar, color,
+            position)
+    {
         var appliedClassName = 'bauten-text-emphasis-applied';
         if(bauten._hasClass(element, appliedClassName)) {
             return;
@@ -79,7 +82,8 @@
                     newChildNodes.push(node);
                     break;
                 case 3:
-                    var em = bauten._applyText(node, emphasisChar, color);
+                    var em = bauten._applyText(node, emphasisChar, color,
+                            position);
                     em.className = appliedClassName;
                     newChildNodes.push(em);
                     break;
@@ -94,12 +98,19 @@
             element.appendChild(node);
         });
     };
-    bauten._applyText = function(textNode, emphasisChar, color) {
+    bauten._applyText = function(textNode, emphasisChar, color,
+            position)
+    {
         var span = d.createElement('SPAN');
         var text = textNode.nodeValue;
         for(var i = 0; i < text.length; i++) {
             var ruby = d.createElement('RUBY');
             span.appendChild(ruby);
+
+            if(position != null) {
+                ruby.setAttribute(
+                        'style', 'ruby-position: ' + position + ';');
+            }
 
             var rb = d.createElement('RB');
             ruby.appendChild(rb);
@@ -130,7 +141,8 @@
     };
     d.addEventListener('DOMContentLoaded', function() {
         if(bauten._styles.length == 0) {
-            bauten( { 'className': 'bauten-text-emphasis', 'style': 'filled dot' });
+            bauten( { 'className': 'bauten-text-emphasis', 'style': 'filled dot',
+                'position' : null /* [over|under] && [left|right] */ });
         }
         bauten._styles.forEach(function(style) {
             bauten._applyAll(bauten._getElementsByStyle(style), style);

--- a/test/emphasis-position.html
+++ b/test/emphasis-position.html
@@ -1,0 +1,39 @@
+<html>
+<head>
+<title>emphasis-position</title>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<style>
+
+em.default {
+    -webkit-text-emphasis-style: open circle;
+    text-emphasis-style: open circle;
+    -webkit-text-emphasis-position: over right;
+    text-emphasis-position: over right;
+}
+strong.default {
+    -webkit-text-emphasis-style: sesame;
+    text-emphasis-style: sesame;
+    -webkit-text-emphasis-position: under right;
+    text-emphasis-position: under right;
+}
+</style>
+</head>
+<body>
+    <h1>emphasis-position</h1>
+<blockquote>
+    <h2>圏点</h2>
+    <p>default: <em class="default">圏点（けんてん）</em>、
+    <strong class="default">傍点（ぼうてん）</strong></p>
+    <p>bauten: <em class="above">圏点（けんてん）</em>、
+    <strong class="below">傍点（ぼうてん）</strong></p>
+</blockquote>
+<script type="text/javascript" src="../bauten.js"></script>
+<script type="text/javascript">
+bauten(
+        { 'tagName': 'EM', 'className':'above', 'style': 'open circle', 'color': 'gray', 'position': 'over right' },
+        { 'tagName': 'STRONG', 'className':'below', 'style': 'sesame', 'color': 'gray', 'position': 'under right' }
+      );
+</script>
+</body>
+</html>
+


### PR DESCRIPTION
- add a property 'position' to the bauten's parameter object.
- the property accepts a value same as a 'text-emphasis-position' of CSS3.
- if it is specified, a 'ruby-position' will be set to RUBY element's 'style' attribute.

But now, I cannot find a user agent rendering properly along that style.
