### PR TITLE
Apply text-emphasis style if it is supported

### DIFF
--- a/bauten.js
+++ b/bauten.js
@@ -65,10 +65,8 @@
             normStyle = [char_style];
         } else {
             var filled_index = 0;
-            if(char_style != null) {
-                if(fill_style != 'open' && fill_style != 'filled') {
-                    throw '"' + fill_style + '" is not recognized as text-emphasis-style';
-                }
+            if(fill_style != 'open' && fill_style != 'filled') {
+                throw '"' + fill_style + '" is not recognized as text-emphasis-style';
             }
             normStyle = [fill_style, char_style];
         }
@@ -188,21 +186,29 @@
         }
     }
     d.addEventListener('DOMContentLoaded', function() {
-        if(bauten._styles.length == 0) {
-            bauten( { 'className': 'bauten-text-emphasis', 'style': 'filled dot',
-                'position' : null /* [over|under] && [left|right] */ });
-        }
-        var applyAll = null;
-        if(bauten._isSupportedCss()) {
-            applyAll = bauten._webkitApplyAll;
-        } else {
-            applyAll = bauten._applyAll;
-        }
-        bauten._styles.forEach(function(style) {
-            if(style != null && style.style != null) {
-                applyAll(bauten._getElementsByStyle(style), style);
+        try {
+            if(bauten._styles.length == 0) {
+                bauten( { 'className': 'bauten-text-emphasis', 'style': 'filled dot',
+                    'position' : null /* [over|under] && [left|right] */ });
             }
-        });
+            var applyAll = null;
+            if(bauten._isSupportedCss()) {
+                applyAll = bauten._webkitApplyAll;
+            } else {
+                applyAll = bauten._applyAll;
+            }
+            bauten._styles.forEach(function(style) {
+                try {
+                    if(style != null && style.style != null) {
+                        applyAll(bauten._getElementsByStyle(style), style);
+                    }
+                } catch (e) {
+                    console.error(e);
+                }
+            });
+        } catch (e) {
+            console.error(e);
+        }
     });
     window['bauten'] = bauten;
 })(document);

--- a/bauten.js
+++ b/bauten.js
@@ -26,18 +26,30 @@
     };
     bauten._regexIgnoredChars = /[\s　\(\)（）\[\]「」［］]/;
     bauten._applyAll = function(elements, style) {
-        if(style != null && style.style != null) {
-            var emphasisChar = bauten._getEmphasisChar(style);
-            if(emphasisChar != null) {
-                elements.forEach(function(element) {
-                    bauten._applyElement(element, emphasisChar, style.color,
-                            style.position);
-                });
-            }
+        var emphasisChar = bauten._getEmphasisChar(style);
+        if(emphasisChar != null) {
+            elements.forEach(function(element) {
+                bauten._applyElement(element, emphasisChar, style.color,
+                        style.position);
+            });
         }
     };
     bauten._getEmphasisChar = function(style) {
         var emphasisChar = null;
+        var normStyle = bauten._parseStyle(style);
+        if(normStyle.length == 1) {
+            if(normStyle[0] != 'none') {
+                emphasisChar = normStyle[0];
+            }
+        } else if(normStyle.length > 1) {
+            var fill_style = normStyle[0];
+            var char_style = normStyle[1];
+            emphasisChar = bauten.styleId2Ch[char_style][fill_style];
+        }
+        return emphasisChar;
+    }
+    bauten._parseStyle = function(style) {
+        var normStyle = null;
         var char_style = 'none';
         var fill_style = 'filled';
         var styles = styles = style.style.split(' ').filter(function(e) { return e != ''; });
@@ -49,20 +61,18 @@
         } else {
             throw '"' + style.style + '" is not recognized as text-emphasis-style';
         }
-        if(char_style != 'none') {
-            if(bauten._styleIds.indexOf(char_style) < 0) {
-                emphasisChar = char_style;
-            } else {
-                var filled_index = 0;
-                if(char_style != null) {
-                    if(fill_style != 'open' && fill_style != 'filled') {
-                        throw '"' + fill_style + '" is not recognized as text-emphasis-style';
-                    }
+        if(bauten._styleIds.indexOf(char_style) < 0) {
+            normStyle = [char_style];
+        } else {
+            var filled_index = 0;
+            if(char_style != null) {
+                if(fill_style != 'open' && fill_style != 'filled') {
+                    throw '"' + fill_style + '" is not recognized as text-emphasis-style';
                 }
-                emphasisChar = bauten.styleId2Ch[char_style][fill_style];
             }
+            normStyle = [fill_style, char_style];
         }
-        return emphasisChar;
+        return normStyle;
     }
     bauten._applyElement = function(element, emphasisChar, color,
             position)
@@ -146,13 +156,52 @@
         }
         return elements;
     };
+    bauten._isSupportedCss = function() {
+        return d.body.style.webkitTextEmphasis != undefined;
+    };
+    bauten._webkitApplyAll = function(elements, style) {
+        elements.forEach(function(element) {
+            bauten._webkitApplyElement(element, style);
+        });
+    };
+    bauten._webkitApplyElement = function(element, style) {
+        var normStyle = bauten._parseStyle(style);
+        if(normStyle.length == 1) {
+            if(normStyle[0] != 'none') {
+                normStyle = "'" + normStyle[0] + "'";
+            } else {
+                normStyle = normStyle[0];
+            }
+        } else if(normStyle.length > 1) {
+            var fill_style = normStyle[0];
+            var char_style = normStyle[1];
+            normStyle = fill_style + ' ' + char_style;
+        } else {
+            return;
+        }
+        element.style.webkitTextEmphasisStyle = normStyle;
+        if(style.color != null) {
+            element.style.webkitTextEmphasisColor = style.color;
+        }
+        if(style.position != null) {
+            element.style.webkitTextEmphasisPosition = style.position;
+        }
+    }
     d.addEventListener('DOMContentLoaded', function() {
         if(bauten._styles.length == 0) {
             bauten( { 'className': 'bauten-text-emphasis', 'style': 'filled dot',
                 'position' : null /* [over|under] && [left|right] */ });
         }
+        var applyAll = null;
+        if(bauten._isSupportedCss()) {
+            applyAll = bauten._webkitApplyAll;
+        } else {
+            applyAll = bauten._applyAll;
+        }
         bauten._styles.forEach(function(style) {
-            bauten._applyAll(bauten._getElementsByStyle(style), style);
+            if(style != null && style.style != null) {
+                applyAll(bauten._getElementsByStyle(style), style);
+            }
         });
     });
     window['bauten'] = bauten;


### PR DESCRIPTION
- The webkit user agent is supporting text-emphasis style
- At execution, it will be checked that is a webkit or not
- The check is done by using a 'document.body.style.webkitTextEmphasis'
- If it is not defined, the user agent does not support that style
- So, text-emphasis will be simulated by RUBY elements
- When it is supported, that style is realized by style attributes
- Feat/check css feature
